### PR TITLE
Mark as deprecated

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,12 @@
 >ℹ️&nbsp;&nbsp;SignalFx was acquired by Splunk in October 2019. See [Splunk SignalFx](https://www.splunk.com/en_us/investor-relations/acquisitions/signalfx.html) for more information.
 
+> # :warning: Deprecation Notice
+> The SignalFx Go Lambda Wrapper is deprecated. Only critical security fixes and bug fixes are provided.
+>
+> Going forward, Lambda functions should use the Splunk OpenTelemetry Lambda Layer, which offers similar capabilities and fully supports the OpenTelemetry standard. To learn more about the Splunk OTel Lambda Layer, see https://docs.splunk.com/Observability/gdi/get-data-in/serverless/aws/otel-lambda-layer/instrument-lambda-functions.html#nav-Instrument-your-Lambda-function
+
+---
+
 # SignalFx Go Lambda Wrapper
 SignalFx Golang Lambda Wrapper.
 


### PR DESCRIPTION
Point to supported OpenTelemetry-based component instead